### PR TITLE
Fix multi-word wildcard handling + add a bunch of test cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
+    
+    - name: Install dependencies
+      run: npm install
+      
+    - name: Run tests
+      run: make test

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 module.exports = function match (actual, expected) {
-  if (actual === expected) return true;
-  var regexString = '^' + expected.replace(/\*/g, '([^.]+)').replace(/#/g, '([^.]+\.?)+') + '$';
-  return actual.search(regexString) !== -1;
+	if (actual === expected) return true;
+	var regexString = '^' +
+		expected.replace(/[.]/g, '\\.') // escape dots
+			.replace(/\*/g, '([^.]+)') // single word wildcard
+			.replace(/^#\\./, '([^.]+[.])*') // multi word wildcard at start of key
+			.replace(/\\.#$/, '([.][^.]+)*') // multi word wildcard at end of key
+			.replace(/\\.#\\./g, '(([.].*[.])*|[.])') // multi word wildcard within key
+			+ '$';
+	return actual.search(regexString) !== -1;
 };
-

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,11 @@ describe('amqp-match', () => {
 		match('this.key', 'this.key').should.eql(true);
 
 	});
+	it('should not match key to this.key (direct inequality)', () => {
+
+		match('key', 'this.key').should.eql(false);
+
+	});
 
 	// Single word wildcard
 	it('should match this.new.key to this.*.key (single word wildcard)', () => {
@@ -28,7 +33,7 @@ describe('amqp-match', () => {
 
 	});
 
-	it('should match this.new.key to *.new.key (end single word wildcard)', () => {
+	it('should match this.new.key to this.new.* (end single word wildcard)', () => {
 
 		match('this.new.key', 'this.new.*').should.eql(true);
 
@@ -43,6 +48,18 @@ describe('amqp-match', () => {
 	it('should not match some.new.kinda.key to this.*.key (single word wildcard)', () => {
 
 		match('some.new.kinda.key', 'this.*.key').should.eql(false);
+
+	});
+
+	it('should not match this.new.key.end to this.new.* (end single word wildcard)', () => {
+
+		match('this.new.key.end', 'this.new.*').should.eql(false);
+
+	});
+
+	it('should not match start.this.new.key to *.new.key (beginning single word wildcard)', () => {
+
+		match('start.this.new.key', '*.new.key').should.eql(false);
 
 	});
 

--- a/test/index.js
+++ b/test/index.js
@@ -63,6 +63,16 @@ describe('amqp-match', () => {
 
 	});
 
+	it('should not match this.new.key to *.* (single word wildcards)', () => {
+		
+		match('this.new.key', '*.*').should.eql(false);
+	});
+
+	it('should match this.key to *.* (single word wildcards)', () => {
+		
+		match('this.key', '*.*').should.eql(true);
+	});
+
 	// Multi word wildcard
 
 	it('should match this.new.kinda.key to this.#.key (multi word wildcard)', () => {
@@ -117,5 +127,20 @@ describe('amqp-match', () => {
 	it('should work on mixed keys', () => {
 
 		match('this.key1.of.key2', '#.key1.*.key2').should.eql(true);
+	});
+
+	it('should fail on bad mixed keys 1', () => {
+
+		match('bad.this.key1.of.key2', 'good.#.key1.*.key2').should.eql(false);
+	});
+
+	it('should fail on bad mixed keys 2', () => {
+
+		match('bad.this.key1.of.key2.end', '#.key1.*.key2').should.eql(false);
+	});
+
+	it('should fail on bad mixed keys 3', () => {
+
+		match('bad.this.key1.of.key2.end', '#.key1.*.key2.*.*').should.eql(false);
 	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
-/*jslint node: true */
+/* jslint node: true */
+/* eslint-env mocha */
 'use strict';
 
 const should = require('should');
@@ -7,34 +8,97 @@ let match = require('../');
 
 describe('amqp-match', () => {
 
-  it('should match this.key to this.key (direct equality)', () => {
+	// Constant
+	it('should match this.key to this.key (direct equality)', () => {
 
-    match('this.key', 'this.key').should.eql(true);
+		match('this.key', 'this.key').should.eql(true);
 
-  });
+	});
 
-  it('should match this.new.key to this.*.key (single word wildcard)', () => {
+	// Single word wildcard
+	it('should match this.new.key to this.*.key (single word wildcard)', () => {
 
-    match('this.new.key', 'this.*.key').should.eql(true);
+		match('this.new.key', 'this.*.key').should.eql(true);
 
-  });
+	});
 
-  it('should not match this.new.other.key to this.*.key (single word wildcard)', () => {
+	it('should match this.new.key to *.new.key (beginning single word wildcard)', () => {
 
-    match('this.new.other.key', 'this.*.key').should.not.eql(true);
+		match('this.new.key', '*.new.key').should.eql(true);
 
-  });
+	});
 
-  it('should match this.new.kinda.key to this.#.key (multi word wildcard)', () => {
+	it('should match this.new.key to *.new.key (end single word wildcard)', () => {
 
-    match('this.new.kinda.key', 'this.#.key').should.eql(true);
+		match('this.new.key', 'this.new.*').should.eql(true);
 
-  });
+	});
 
-  it('should not match some.new.kinda.key to this.#.key (single word wildcard)', () => {
+	it('should not match this-new.key to this.*.key (single word wildcard)', () => {
 
-    match('some.new.kinda.key', 'this.#.key').should.not.eql(true);
+		match('this-new.key', 'this.*.key').should.eql(false);
 
-  });
+	});
 
+	it('should not match some.new.kinda.key to this.*.key (single word wildcard)', () => {
+
+		match('some.new.kinda.key', 'this.*.key').should.eql(false);
+
+	});
+
+	// Multi word wildcard
+
+	it('should match this.new.kinda.key to this.#.key (multi word wildcard)', () => {
+
+		match('this.new.kinda.key', 'this.#.key').should.eql(true);
+
+	});
+
+	it('should match this.key to this.#.key (multi word wildcard with empty matching)', () => {
+
+		match('this.key', 'this.#.key').should.eql(true);
+
+	});
+
+	it('should match this.kind.of.key.end to this.kind.of.# (end of key wildcard)', () => {
+
+		match('this.kind.of.key.end', 'this.kind.of.#').should.eql(true);
+	});
+
+	it('should match this.kind.of to this.kind.of.# (end of key wildcard without end)', () => {
+
+		match('this.kind.of', 'this.kind.of.#').should.eql(true);
+	});
+
+	it('should match this.kind.of.key.end to this.#.key.# (multi wildcard with end of key wildcard)', () => {
+
+		match('this.kind.of.key.end', 'this.#.key.#').should.eql(true);
+	});
+
+	it('should match this.kind.of.key.end to this.#.key.# (multi wildcard with end of key wildcard and no end of key)', () => {
+
+		match('this.kind.of.key', 'this.#.key.#').should.eql(true);
+	});
+
+	it('should not match wildcard with bad constant parts', () => {
+
+		match('this.kind.of.notkey', 'this.#.key.#').should.eql(false);
+	});
+
+	it('should match multi word wildcard at beginning of string', () => {
+
+		match('this.kind.of.key', '#.key').should.eql(true);
+	});
+
+	it('should not match multi word wildcard at beginning of string with bad constant part', () => {
+
+		match('this.kind.of.notkey', '#.key').should.eql(false);
+	});
+
+	// Mixed
+
+	it('should work on mixed keys', () => {
+
+		match('this.key1.of.key2', '#.key1.*.key2').should.eql(true);
+	});
 });


### PR DESCRIPTION
Fixes a few cases which differ from amqp handling and add corresponding tests:
- `#.foo` should match `foo`
- `foo.#` should match `foo`
- `foo.#.bar` should match `foo.bar`

also fixes https://github.com/mateodelnorte/amqp-match/issues/3